### PR TITLE
always put finger numbers in technical articulation

### DIFF
--- a/pianoplayer/hand.py
+++ b/pianoplayer/hand.py
@@ -214,18 +214,9 @@ class Hand:
                 if an.isChord:
                     if an.chord21.style:
                         an.chord21.style.absoluteX = an.chord21._notes[0]._style.absoluteX
-                    if self.lyrics:
-                         if len(an.chord21.pitches) <= 3:
-                             # dont show fingering in the lyrics line for >3 note-chords
-                             nl = len(an.chord21.pitches) - an.chordnr
-                             an.chord21.addLyric(best_finger, nl)
-                    else:
-                        an.chord21.articulations.append(fng)
+                    an.chord21.articulations.append(fng)
                 else:
-                    if self.lyrics:
-                        an.note21.addLyric(best_finger)
-                    else:
-                        an.note21.articulations.append(fng)
+                    an.note21.articulations.append(fng)
 
 
             #-----------------------------


### PR DESCRIPTION
I think the lyrics look better when viewing in Sibelius, which is why the original author tried to put the finger numbers in the lyrics when possible. But it's easier for us to always have them in the articulations. That way it will always show up as
`<notations>
          <technical>
            <fingering alternate="no" substitution="no">1</fingering>
          </technical>
        </notations>`